### PR TITLE
安定性向上: GitHub Actionsの最大実行時間を15分に制限

### DIFF
--- a/.github/workflows/update-pages.yml
+++ b/.github/workflows/update-pages.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Inspect files before checkout


### PR DESCRIPTION
## 概要
GitHub Actionsはデフォルトで最大360分（6時間）タイムアウトしない仕様になっています。
何らかの予測不可能な外部要因（ネットワーク遮断や特定のAPIのハングなど）によってステップが無限待機に陥った場合、Actionsの無料枠（利用時間）が大量に消費されてしまう危険性があります。

## 変更内容
\uild\ ジョブに対して \	imeout-minutes: 15\ を明示的に設定しました。
これにより、万が一処理が15分以上固まった場合には強制的にフェイルセーフとしてジョブがキャンセルされるようになり、意図しない利用リソースの枯渇を防ぐことができます。