### PR TITLE
修正: PuppeteerのChromiumダウンロードスキップ指定をv19以降に対応

### DIFF
--- a/.github/workflows/update-pages.yml
+++ b/.github/workflows/update-pages.yml
@@ -27,7 +27,7 @@ jobs:
           cache: 'npm'
       - name: Install npm Package
         run: |
-          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm ci
+          PUPPETEER_SKIP_DOWNLOAD=true PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm ci
       - name: copyfiles
         run: |
           for platform in PC Quest; do


### PR DESCRIPTION
## 概要
Puppeteer v19以降の仕様に合わせ、Chromiumダウンロードをスキップするための環境変数を正しいものに修正します。

## 修正内容
\update-pages.yml\ の \
pm ci\ ステップにおいて、\PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true\（古い仕様）を \PUPPETEER_SKIP_DOWNLOAD=true\（新しい仕様）に変更しました。
※念のため両方指定していますが、主体は \PUPPETEER_SKIP_DOWNLOAD\ になります。

これにより、GitHub Actions 上での150MBの巨大バイナリのダウンロードが正しくスキップされ、タイムアウト・ハングアップが解消されるはずです。

Close #11