### PR TITLE
修正: 不正な画像ファイルによる描画時のクラッシュを防ぐ処理の追加

### DIFF
--- a/.github/workflows/update-pages.yml
+++ b/.github/workflows/update-pages.yml
@@ -32,12 +32,13 @@ jobs:
         run: |
           for platform in PC Quest; do
             for i in {0..35}; do
-              curl -s -f -o work/base_${platform}_${i}.jpg "https://namanonamako.github.io/world-discover-poster/base_${platform}_${i}.jpg" || true
-              curl -s -f -o work/base_${platform}_d_${i}.jpg "https://namanonamako.github.io/world-discover-poster/base_${platform}_d_${i}.jpg" || true
+              curl --retry-all-errors --retry 3 --retry-delay 2 -s -f -o work/base_${platform}_${i}.jpg "https://namanonamako.github.io/world-discover-poster/base_${platform}_${i}.jpg" || rm -f work/base_${platform}_${i}.jpg
+              curl --retry-all-errors --retry 3 --retry-delay 2 -s -f -o work/base_${platform}_d_${i}.jpg "https://namanonamako.github.io/world-discover-poster/base_${platform}_d_${i}.jpg" || rm -f work/base_${platform}_d_${i}.jpg
             done
           done
-          curl -s -f -o work/posterInfo.json https://namanonamako.github.io/world-discover-poster/posterInfo.json || true
-          curl -s -f -o work/posterData.json http://keisotsuna.servebeer.com:9000/posterData.json || rm -f work/posterData.json
+          curl --retry-all-errors --retry 3 --retry-delay 2 -s -f -o work/posterInfo.json https://namanonamako.github.io/world-discover-poster/posterInfo.json || rm -f work/posterInfo.json
+          curl --retry-all-errors --retry 3 --retry-delay 2 -s -f -o work/posterData.json http://keisotsuna.servebeer.com:9000/posterData.json || rm -f work/posterData.json
+          find work -type f -empty -delete
       - name: Set UTF-8 locale
         run: sudo apt-get update && sudo apt-get install -y language-pack-ja && sudo update-locale LANG=ja_JP.UTF-8
       - name: Install Japanese fonts

--- a/app.js
+++ b/app.js
@@ -57,10 +57,10 @@ async function create_merged_picture(platform_name, isDarkMode, imageID) {
     context.fillRect(0, 0, canvas.width, canvas.height);
     for (let i = 0; i < rows * cols; i++) {
         const filePath = path.join("images", `base_${platform_name}${isDarkMode ? "_d" : ""}_${i + imageID * (rows * cols)}.jpg`);
-        if (fs.existsSync(filePath)) {
+        if (fs.existsSync(filePath) && fs.statSync(filePath).size > 0) {
             await load_image_and_draw(context, filePath, i % (rows + 1), Math.floor(i / cols));
         } else {
-            console.log(`${filePath}ファイルが見つからないのでスキップします。`);
+            console.log(`${filePath}が0バイトか存在しないため配置をスキップします。`);
         }
     }
     const pngData = await canvas.encode('png');
@@ -176,7 +176,7 @@ async function create_basepic(platform_name, datas) {
             const filePath_d = path.join("images/", `base_${platform_name}_d_${i}.jpg`);
             console.log(`${i + 1}枚目の移動を開始します`);
             results.push((async () => {
-                if (fs.existsSync(old_filePath)) {
+                if (fs.existsSync(old_filePath) && fs.statSync(old_filePath).size > 0) {
                     try {
                         await fs.promises.copyFile(old_filePath, filePath);
                         console.log(`${i + 1}枚目の移動が完了しました`);
@@ -185,7 +185,7 @@ async function create_basepic(platform_name, datas) {
                         throw err;
                     }
                 }
-                if (fs.existsSync(old_filePath_d)) {
+                if (fs.existsSync(old_filePath_d) && fs.statSync(old_filePath_d).size > 0) {
                     try {
                         await fs.promises.copyFile(old_filePath_d, filePath_d);
                         console.log(`${i + 1}枚目ダークモードの移動が完了しました`);


### PR DESCRIPTION
## 概要
GitHub Actions のワークフロー内で発生する、`Error: Unsupported image type` による画像生成失敗エラーの根本解決を行います。

## 原因と修正内容
原因は、`update-pages.yml` 内の `curl` コマンドによる画像ダウンロード時に、**一時的なネットワークエラーやサーバー側のレート制限（429エラーや503エラー等）**によってダウンロードが失敗した場合でも、`curl -f` コマンドがエラー終了する前に「0バイトの空の画像ファイル」を生成してしまうことでした。

この空ファイルが `app.js` の画像合成処理に渡されると、Cavasライブラリがパースできずにクラッシュしていました。

今回の修正では、**YAML側とJS側の二段構えの防壁**を導入して処理を堅牢化します。

### 1. `update-pages.yml` 側の修正（ゴミファイルの生成防止）
- 各 `curl` コマンドに `--retry-all-errors --retry 3 --retry-delay 2` を付与し、一時的なネットワークエラー時に数秒待機して自動リトライするようにしました。
- それでも失敗した場合は `|| rm -f [保存先]` を実行し、生成されてしまった0バイトのゴミファイルを即座に削除するようにしました。
- 念のため実行後のディレクトリ全域に対し `find work -type f -empty -delete` をかけ、空ファイルの一掃処理を追加しました。

### 2. `app.js` 側の修正（JS側の防御強化）
- `fs.existsSync` によるファイル存在確認だけでなく、`fs.statSync(filePath).size > 0` を追加し、万が一空ファイルが紛れ込んでいた場合は単にエラー終了せずスキップして次へ進むように改修しました。
