### PR TITLE
機能追加: ブラックリストをGitHub Variablesから読み込むように変更し運用を簡略化

### DIFF
--- a/.github/workflows/update-pages.yml
+++ b/.github/workflows/update-pages.yml
@@ -44,6 +44,8 @@ jobs:
       - name: Install Japanese fonts
         run: sudo apt-get install -y fonts-noto-cjk
       - name: start action...
+        env:
+          BLACKLIST: ${{ vars.BLACKLIST }}
         run: >
           node app.js
       - name: check results

--- a/app.js
+++ b/app.js
@@ -4,8 +4,10 @@ const axios = require("axios");
 const puppeteer = require('puppeteer');
 const { loadImage, createCanvas } = require('@napi-rs/canvas');
 
-// ブラックリスト
-const blackList = ["planetvrchat","vrc14kawa", "ryo777cluster", "vrcfoxabc", "_NEO236_", "j41jjGFfVX45373", "Bocchi_ch1111", "rabyru16843", "VRChatWorldBot", "okasan0725", "Cocochan184_VRC"]
+// ブラックリストを環境変数から取得（カンマ区切りで入力されることを想定）
+const blackListEnv = process.env.BLACKLIST || "";
+const blackList = blackListEnv ? blackListEnv.split(',').map(id => id.trim()).filter(id => id.length > 0) : [];
+console.log(`ロードされたブラックリスト: ${blackList}`);
 
 // タイルのサイズ
 const tileWidth = 550;


### PR DESCRIPTION
## 概要
これまで直接ソースコード（\pp.js\）内に書き込まれていたブラックリスト配列（\lackList\）を外部化し、GitHub Actions機能である **Variables (環境変数)** によって管理できるようにしました。

## 修正内容
1. **\pp.js\**:
   配列 \lackList\ の定義を、環境変数 \process.env.BLACKLIST\ から読み取ってカンマ区切りで生成するように変更しました。
2. **\update-pages.yml\**:
   \
ode app.js\ 実行ステップの直前で、リポジトリに設定された値 (\ars.BLACKLIST\) を環境変数としてNodeスクリプトに渡すようにしました。

## 効果・ご利用方法
これにより、今後はブラックリストの追加・削除のたびにソースコードを編集してコミットする必要がなくなり、プログラムを壊してしまうリスクがゼロになります！

**使い方:**
1. このPRをマージします。
2. このリポジトリの **[Settings]** タブを開きます。
3. 左メニューから **[Secrets and variables]** > **[Actions]** と進みます。
4. **[Variables]** タブ（Secretsの隣）を開き、**[New repository variable]** をクリックします。
5. Nameに \BLACKLIST\ と入力し、Valueにカンマ区切りでIDを入力して（例: \rc14kawa, ryo777cluster, vrcfoxabc\）Saveします。
6. 次回のアクション実行から即座に反映されます。

Close #15