### PR TITLE
修正: 画像取得失敗時に枠に穴が空かないようにリトライとスキップ処理を追加

### DIFF
--- a/app.js
+++ b/app.js
@@ -75,6 +75,7 @@ async function create_merged_picture(platform_name, isDarkMode, imageID) {
  * @param {string} path 生成した画像の保存先パス
  */
 async function screenshot_tweet_pic(browser, tweetUrl, path, isDarkMode) {
+    let success = false;
     await axios.get(`https://publish.twitter.com/oembed?url=${tweetUrl}&partner=&hide_thread=false&theme=${isDarkMode ? "dark" : "light"}`).then(async response => {
         try {
             const page = await browser.newPage();
@@ -106,13 +107,14 @@ async function screenshot_tweet_pic(browser, tweetUrl, path, isDarkMode) {
             await page.screenshot({ path: path });
             console.log(`キャプチャしました`);
             await page.close();
+            success = true;
         } catch (e) {
             console.log("キャプチャに失敗しました。");
-            throw e;
         }
     }).catch(err => {
         console.log(`ツイート情報取得エラー: ${err.message}`);
     });
+    return success;
 }
 
 const MAX_TWEETPIC_NUM = 36;
@@ -145,20 +147,37 @@ async function create_basepic(platform_name, datas) {
                 if (containsBlacklistWord) {
                     console.log(`BlackList対象です:${datas[i].url}`);
                 } else {
-                    console.log(`${pic_count + 1}枚目の処理を開始します`);
-                    var filePath = path.join("images/", `base_${platform_name}_${pic_count}.jpg`);
-                    await screenshot_tweet_pic(browser, datas[i].url, filePath, false);
-                    console.log(`${pic_count + 1}枚目ダークモードの処理を開始します`);
-                    filePath = path.join("images/", `base_${platform_name}_d_${pic_count}.jpg`);
-                    await screenshot_tweet_pic(browser, datas[i].url, filePath, true);
-                    console.log(`${pic_count + 1}枚目の出力が完了しました`);
-                    // ワールドIDを保存
-                    world_id_array.push(datas[i].world_id);
-                    pic_count += 1;
+                    let success = false;
+                    for (let retry = 0; retry < 3; retry++) {
+                        console.log(`${pic_count + 1}枚目の処理を開始します (Try ${retry + 1})`);
+                        var filePath = path.join("images/", `base_${platform_name}_${pic_count}.jpg`);
+                        const res1 = await screenshot_tweet_pic(browser, datas[i].url, filePath, false);
+
+                        console.log(`${pic_count + 1}枚目ダークモードの処理を開始します (Try ${retry + 1})`);
+                        var filePath_d = path.join("images/", `base_${platform_name}_d_${pic_count}.jpg`);
+                        const res2 = await screenshot_tweet_pic(browser, datas[i].url, filePath_d, true);
+
+                        if (res1 && res2) {
+                            success = true;
+                            break;
+                        } else {
+                            console.log(`キャプチャに失敗したため、3秒待機してリトライします...`);
+                            await new Promise(resolve => setTimeout(resolve, 3000));
+                        }
+                    }
+
+                    if (success) {
+                        console.log(`${pic_count + 1}枚目の出力が完了しました`);
+                        // ワールドIDを保存
+                        world_id_array.push(datas[i].world_id);
+                        pic_count += 1;
+                    } else {
+                        console.log(`${datas[i].url} のキャプチャに完全に失敗したためスキップし、次のツイートを処理します。`);
+                    }
                 }
             } catch (e) {
                 console.log(e.message);
-                console.log(`${pic_count + 1}枚目の処理に失敗しました。`);
+                console.log(`${pic_count + 1}枚目の処理中に予期せぬエラーが発生しました。`);
             }
         };
     } finally {


### PR DESCRIPTION
## 概要
これまで、キャプチャ対象のツイート情報を取得する際にエラー（例: \oembed\ APIの \403 Forbidden\）が発生した場合、**画像自体は生成されずにポスターの枠「1枚分」としてカウントされて隙間（透明な穴）が空いてしまう**問題がありました。

この問題を根本的に解決するため、各ツイートのキャプチャ処理に対して「リトライ」と「スキップ＆穴埋め」のロジックを追加しました。

## 修正内容
1. **リトライ処理の導入**
   - キャプチャ中に例外が発生した場合、すぐに諦めずに**3秒待機してから再度取得**を試みます。
   - 一時的な通信エラーやレート制限であれば、このリトライによって救済される可能性が高まります。
   - 最大3回までリトライを行います。

2. **完全失敗時のスキップと穴埋め**
   - 3回リトライしてもキャプチャできなかった「重度のエラー（URLが無効など）」のツイートについては、**生成枚数の枠（\pic_count\）を増やさずに完全にスキップ**します。
   - これにより、エラーとなったツイートの代わりに「次に見つかった正常なツイート」が自動的に前倒しで穴埋めされるため、ポスター内に意味不明な空欄ができるのを防ぐことができます。

Close #18