### PR TITLE
高速化: 日本語フォントのインストールをキャッシュ化しタイムアウトを防止

### DIFF
--- a/.github/workflows/update-pages.yml
+++ b/.github/workflows/update-pages.yml
@@ -39,13 +39,28 @@ jobs:
           curl --retry-all-errors --retry 3 --retry-delay 2 -s -f -o work/posterInfo.json https://namanonamako.github.io/world-discover-poster/posterInfo.json || rm -f work/posterInfo.json
           curl --retry-all-errors --retry 3 --retry-delay 2 -s -f -o work/posterData.json http://keisotsuna.servebeer.com:9000/posterData.json || rm -f work/posterData.json
           find work -type f -empty -delete
-      - name: Set UTF-8 locale
-        run: sudo apt-get update && sudo apt-get install -y language-pack-ja && sudo update-locale LANG=ja_JP.UTF-8
+      - name: Cache fonts
+        id: cache-fonts
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/fonts
+          key: jp-fonts-v1
       - name: Install Japanese fonts
-        run: sudo apt-get install -y fonts-noto-cjk
+        run: |
+          if [ "${{ steps.cache-fonts.outputs.cache-hit }}" != "true" ]; then
+            mkdir -p ~/.local/share/fonts
+            curl -L https://github.com/googlefonts/noto-fonts/raw/main/hinted/otf/NotoSansJP/NotoSansJP-Regular.otf -o ~/.local/share/fonts/NotoSansJP-Regular.otf
+          fi
+          fc-cache -fv
+      - name: Set UTF-8 locale
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y language-pack-ja
+          sudo update-locale LANG=ja_JP.UTF-8
       - name: start action...
         env:
           BLACKLIST: ${{ vars.BLACKLIST }}
+          LANG: ja_JP.UTF-8
         run: >
           node app.js
       - name: check results


### PR DESCRIPTION
## 概要
GitHub Actions の実行中に \onts-noto-cjk\（100MB超）のインストールで15分以上かかりタイムアウトする問題を解決します。

## 修正内容
1. **フォントのキャッシュ対応**
   \ctions/cache\ を導入し、一度ダウンロードしたフォントファイルを GitHub 側にキャッシュするようにしました。2回目以降の実行ではダウンロード時間が **0秒** になります。
2. **直接ダウンロードへの切り替え**
   パッケージ管理（apt-get）を介さず、Google Fonts のリポジトリから日本語フォント (\Noto Sans JP\) のみを直接ダウンロードするように変更しました。これにより初回ダウンロードも大幅に高速化されます。
3. **ロケール設定の安定化**
   Node.js の実行環境に明示的に \LANG: ja_JP.UTF-8\ を指定し、文字化けのリスクを低減しました。

## 期待される効果
- 以前は数分〜15分以上かかっていたフォント準備ステップが、**初回数十秒、2回目以降はほぼ0秒**で完了するようになります。